### PR TITLE
Add cra-sbom-evidence to validation and quality scoring tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ CRA Annex I Part II (1) obliges manufacturers to identify and document the compo
 *Validation and quality scoring:*
 
 - [bomber](https://github.com/devops-kung-fu/bomber) - SBOM vulnerability scanner with pluggable data-provider backends. *Apache-2.0.*
+- [cra-sbom-evidence](https://github.com/plusultra-tools/cra-sbom-evidence) - CRA Annex I Part II (1) preflight: scores a CycloneDX/SPDX SBOM against BSI TR-03183-2 mandatory fields and emits an Article 14 evidence bundle. *MIT.*
 - [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli) - Schema validation, format conversion, and SBOM merge/diff operations. *Apache-2.0.*
 - [ntia-conformance-checker](https://github.com/spdx/ntia-conformance-checker) - Automated NTIA Minimum Elements verification for SPDX SBOMs. *Apache-2.0.*
 - [sbomqs](https://github.com/interlynk-io/sbomqs) - Quality and compliance scorer with built-in profiles for BSI TR-03183-2, NTIA Minimum Elements, FSCT v3, and OpenChain Telco. *Apache-2.0.*


### PR DESCRIPTION
Adds [cra-sbom-evidence](https://github.com/plusultra-tools/cra-sbom-evidence) to the *Validation and quality scoring* section under Vulnerability Handling & Reporting > SBOM & Transparency.

What it does:
- Reads a CycloneDX 1.5/1.6 or SPDX 2.3 SBOM file.
- Scores it against BSI TR-03183-2 mandatory and recommended fields and against NTIA Minimum Elements.
- Emits a JSON evidence bundle plus a human-readable report intended as Article 14(2) supporting documentation for the technical file.
- Exit codes are deterministic (0 pass, 1 missing-mandatory, 2 schema-fail) so the tool slots into a CI gate.

What it adds beyond sbomqs / ntia-conformance-checker:
- The output is structured as an *evidence bundle* (claim + cited clause + the SBOM field that supports it), not just a score. The intent is to drop the bundle into the Annex VII technical documentation alongside the SBOM itself.
- BSI TR-03183-2 v2.0 profile is enforced verbatim; the citation strings come from the BSI text so an auditor can verify the mapping.

MIT-licensed, single-binary Python CLI. Entry placed alphabetically (c-section) in the Validation list.

Disclosure: I am the author.