### PR TITLE
Add CausalLayer — AI liability attribution for EU compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,3 +395,5 @@ This list is curated and maintained by **Jeans Koo** at **The One Testing Techno
 - ✉️ [jeans.koo@theonelab.co](mailto:jeans.koo@theonelab.co)
 
 *For questions, corrections, or to contribute a resource, open an issue or pull request — see [CONTRIBUTING.md](CONTRIBUTING.md).*
+
+- [CausalLayer MCP](https://github.com/smq9sn5jck-coder/causallayer-mcp) - Deterministic liability attribution for AI systems, designed for EU regulatory compliance including AI Act and CRA overlap areas.


### PR DESCRIPTION
CausalLayer provides deterministic AI liability attribution designed for EU regulatory compliance. While primarily targeting the AI Act, it addresses overlapping CRA requirements for AI-enabled products.

Repo: https://github.com/smq9sn5jck-coder/causallayer-mcp